### PR TITLE
enhance pakcage version align command with level 2 deps

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -147,3 +147,8 @@ export const readJsonFile = (filePath) => {
   const jsonData = fs.readFileSync(filePath, 'utf8');
   return JSON.parse(jsonData);
 };
+
+export const readYmlFile = (filePath) => {
+  const ymlData = fs.readFileSync(filePath, 'utf8');
+  return YAML.parse(ymlData);
+};


### PR DESCRIPTION
With this PR, we can align not only the application's dependencies but also the version mismatches of dependent peer applications and frontend-components packages. Try following command:

insights-interact run alignPackages --app=patchman-ui  --packages=@patternfly/react-core,@scalprum/react-core


After scaffolding enhancement [PR](https://github.com/scalprum/scaffolding/pull/97#discussion_r1158434440) gets merged, we can just copy paste the available command and align all packages upto level 2.